### PR TITLE
fix return type on leaf-midi.c tSimplePoly_allNotesOff

### DIFF
--- a/leaf/Src/leaf-midi.c
+++ b/leaf/Src/leaf-midi.c
@@ -811,7 +811,7 @@ int tSimplePoly_markPendingNoteOff(tSimplePoly* const poly, uint8_t note)
     return deactivatedVoice;
 }
 
-int tSimplePoly_allNotesOff(tSimplePoly* const poly)
+void tSimplePoly_allNotesOff(tSimplePoly* const poly)
 {
     for (int i = 0; i < poly->stack->size; i++)
     {
@@ -830,6 +830,7 @@ int tSimplePoly_allNotesOff(tSimplePoly* const poly)
         }
     }
 }
+
 void tSimplePoly_setNumVoices(tSimplePoly* const poly, uint8_t numVoices)
 {
     poly->numVoices = (numVoices > poly->maxNumVoices) ? poly->maxNumVoices : numVoices;


### PR DESCRIPTION
In leaf-midi.c tSimplePoly_allNotesOff was declared to return int but did not return anything. The only caller did not use the (non)-returned result.

Change the definition to void to allow compilation within Espressif's idf.py for ESP32 platforms.